### PR TITLE
Fixed leg twitching and fixed camera surface overlap bug

### DIFF
--- a/Source/ALSV4_CPP/Private/Character/ALSPlayerCameraManager.cpp
+++ b/Source/ALSV4_CPP/Private/Character/ALSPlayerCameraManager.cpp
@@ -153,7 +153,7 @@ bool AALSPlayerCameraManager::CustomCameraBehavior(float DeltaTime, FVector& Loc
 	World->SweepSingleByChannel(HitResult, TraceOrigin, TargetCameraLocation, FQuat::Identity,
 	                            TraceChannel, FCollisionShape::MakeSphere(TraceRadius), Params);
 
-	if (HitResult.IsValidBlockingHit())
+	if (HitResult.bBlockingHit)
 	{
 		TargetCameraLocation += (HitResult.Location - HitResult.TraceEnd);
 	}

--- a/Source/ALSV4_CPP/Private/Character/Animation/ALSCharacterAnimInstance.cpp
+++ b/Source/ALSV4_CPP/Private/Character/Animation/ALSCharacterAnimInstance.cpp
@@ -326,7 +326,7 @@ void UALSCharacterAnimInstance::SetFootLocking(float DeltaSeconds, FName EnableF
 	// unnaturally.
 	const float InterpSpeed = 90.0f;
 
-	if (CurFootLockLoc == FVector::ZeroVector)
+	if (CurFootLockLoc == FVector::ZeroVector || Character->GetLocalRole() != ROLE_AutonomousProxy)
 	{
 		CurFootLockLoc = TargetFootLockLoc;
 		CurFootLockRot = TargetFootLockRot;
@@ -519,7 +519,7 @@ void UALSCharacterAnimInstance::DynamicTransitionCheck()
 	if (Distance > Config.DynamicTransitionThreshold)
 	{
 		FALSDynamicMontageParams Params;
-		Params.Animation = TransitionAnim_L;
+		Params.Animation = TransitionAnim_R;
 		Params.BlendInTime = 0.2f;
 		Params.BlendOutTime = 0.2f;
 		Params.PlayRate = 1.5f;
@@ -533,7 +533,7 @@ void UALSCharacterAnimInstance::DynamicTransitionCheck()
 	if (Distance > Config.DynamicTransitionThreshold)
 	{
 		FALSDynamicMontageParams Params;
-		Params.Animation = TransitionAnim_R;
+		Params.Animation = TransitionAnim_L;
 		Params.BlendInTime = 0.2f;
 		Params.BlendOutTime = 0.2f;
 		Params.PlayRate = 1.5f;

--- a/Source/ALSV4_CPP/Public/Library/ALSAnimationStructLibrary.h
+++ b/Source/ALSV4_CPP/Public/Library/ALSAnimationStructLibrary.h
@@ -483,7 +483,7 @@ struct FALSAnimConfiguration
 
 	/** Threshold value for activating dynamic transition on various animations */
 	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	float DynamicTransitionThreshold = 12.0f;
+	float DynamicTransitionThreshold = 8.0f;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly)
 	float IK_TraceDistanceAboveFoot = 50.0f;


### PR DESCRIPTION
Fixed the leg twitching issue created by reversed animation asset reference when playing dynamic foot transition animation so I've reduced the transition threshold to original ALS BP value. I've also managed to fix the camera overlapping issue referenced in #23. The character's feet would also "snap" into place when playing as listen server or offline so I've added an extra condition to #46's foot locking fix